### PR TITLE
Add handler for EL8 to map.jinja file

### DIFF
--- a/pillar/common/scap/map.jinja
+++ b/pillar/common/scap/map.jinja
@@ -72,6 +72,17 @@
                 'profile': 'profile_stig' if os == 'rhel' else 'stig'
             },
             'scc_source': 'https://watchmaker.cloudarmor.io/repo/spawar/scc/scc-5.5.rhel7.x86_64.rpm'
+        },
+        '8': {
+            'guide_patterns': [
+                'disa/stig-el' ~ grains['osmajorrelease'] ~ '-scap_1-2'
+            ],
+            'oscap': {
+                'xccdf': 'openscap/ssg-' ~ os ~ '8-xccdf.xml',
+                'cpe': 'openscap/ssg-rhel8-cpe-dictionary.xml',
+                'profile': 'profile_stig' if os == 'rhel' else 'stig'
+            },
+            'scc_source': 'https://watchmaker.cloudarmor.io/repo/spawar/scc/scc-5.5.rhel8.x86_64.rpm'
         }
     }, grain='osmajorrelease')) %}
 


### PR DESCRIPTION
Hand validated that the proposed content works past the `NoneType` watchmaker-exit when calling `do oscap.update`