### PR TITLE
Updates profile used by rhel, as "profile_stig" no longer exists

### DIFF
--- a/pillar/common/scap/map.jinja
+++ b/pillar/common/scap/map.jinja
@@ -69,7 +69,7 @@
             'oscap': {
                 'xccdf': 'openscap/ssg-' ~ os ~ '7-xccdf.xml',
                 'cpe': 'openscap/ssg-rhel7-cpe-dictionary.xml',
-                'profile': 'profile_stig' if os == 'rhel' else 'stig'
+                'profile': 'stig'
             },
             'scc_source': 'https://watchmaker.cloudarmor.io/repo/spawar/scc/scc-5.5.rhel7.x86_64.rpm'
         },
@@ -80,7 +80,7 @@
             'oscap': {
                 'xccdf': 'openscap/ssg-' ~ os ~ '8-xccdf.xml',
                 'cpe': 'openscap/ssg-rhel8-cpe-dictionary.xml',
-                'profile': 'profile_stig' if os == 'rhel' else 'stig'
+                'profile': 'stig'
             },
             'scc_source': 'https://watchmaker.cloudarmor.io/repo/spawar/scc/scc-5.5.rhel8.x86_64.rpm'
         }


### PR DESCRIPTION
Was reviewing the scap scan results, and noticed we were missing results for RHEL. Found this in the logs:

```
2022-09-22 12:37:21,533 [salt.state       :2065][INFO    ][10649] Running state [(oscap xccdf eval --profile profile_stig --report /root/scap/output/oscap-report.openscap.ssg-rhel7-xccdf.xml.$(date "+%Y%m%d%H%M").html --results /root/scap/output/oscap-results.openscap.ssg-rhel7-xccdf.xml.$(date "+%Y%m%d%H%M").xml --cpe /root/scap/content/openscap/ssg-rhel7-cpe-dictionary.xml /root/scap/content/openscap/ssg-rhel7-xccdf.xml) || true] at time 12:37:21.533217
2022-09-22 12:37:21,534 [salt.state       :2097][INFO    ][10649] Executing state cmd.run for [(oscap xccdf eval --profile profile_stig --report /root/scap/output/oscap-report.openscap.ssg-rhel7-xccdf.xml.$(date "+%Y%m%d%H%M").html --results /root/scap/output/oscap-results.openscap.ssg-rhel7-xccdf.xml.$(date "+%Y%m%d%H%M").xml --cpe /root/scap/content/openscap/ssg-rhel7-cpe-dictionary.xml /root/scap/content/openscap/ssg-rhel7-xccdf.xml) || true]
2022-09-22 12:37:21,535 [salt.loaded.int.module.cmdmod:417 ][INFO    ][10649] Executing command '(oscap' in directory '/root'
2022-09-22 12:37:24,708 [salt.loaded.int.module.cmdmod:881 ][DEBUG   ][10649] stderr: WARNING: This content points out to the remote resources. Use `--fetch-remote-resources' option to download them.
WARNING: Skipping https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2 file which is referenced from XCCDF content
No profile matching suffix "profile_stig" was found. Get available profiles using:
$ oscap info "/root/scap/content/openscap/ssg-rhel7-xccdf.xml"
2022-09-22 12:37:24,709 [salt.state       :315 ][INFO    ][10649] {'pid': 7350, 'retcode': 0, 'stdout': '', 'stderr': 'WARNING: This content points out to the remote resources. Use `--fetch-remote-resources\' option to download them.\nWARNING: Skipping https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2 file which is referenced from XCCDF content\nNo profile matching suffix "profile_stig" was found. Get available profiles using:\n$ oscap info "/root/scap/content/openscap/ssg-rhel7-xccdf.xml"'}
2022-09-22 12:37:24,709 [salt.state       :2252][INFO    ][10649] Completed state [(oscap xccdf eval --profile profile_stig --report /root/scap/output/oscap-report.openscap.ssg-rhel7-xccdf.xml.$(date "+%Y%m%d%H%M").html --results /root/scap/output/oscap-results.openscap.ssg-rhel7-xccdf.xml.$(date "+%Y%m%d%H%M").xml --cpe /root/scap/content/openscap/ssg-rhel7-cpe-dictionary.xml /root/scap/content/openscap/ssg-rhel7-xccdf.xml) || true] at time 12:37:24.709194 (duration_in_ms=3175.977)
```