### PR TITLE
Adds mapping-support to allow use with OL8

### DIFF
--- a/pillar/common/ash-linux/init.sls
+++ b/pillar/common/ash-linux/init.sls
@@ -1,7 +1,10 @@
-{%- set os = grains['os'] |lower %}
-{%- if os == 'redhat' %}
-    {%- set os = 'rhel' %}
-{%- endif %}
+{%- set os = salt.grains.filter_by({
+    'RedHat': 'rhel',
+    'OEL': 'ol',
+    'CentOS': 'centos',
+    'Rocky': 'centos',
+    'AlmaLinux': 'centos'
+}, grain='os') %}
 
 ash-linux:
   lookup:

--- a/pillar/common/scap/map.jinja
+++ b/pillar/common/scap/map.jinja
@@ -57,8 +57,11 @@
 {%- elif family == 'redhat' %}
 
     {%- set os = salt.grains.filter_by({
+        'AlmaLinux': 'centos',
+        'CentOS': 'centos',
+        'OEL': 'ol',
         'RedHat': 'rhel',
-        'CentOS': 'centos'
+        'Rocky': 'centos'
     }, grain='os') %}
 
     {%- do scap.update(salt.grains.filter_by({


### PR DESCRIPTION
OS grain-mappings to include maps from `OEL` to `ol`.

Also aligns the mapping-method with other watchmaker-related projects'.

Closes #29