### PR TITLE
Renamed mcafee to trellix agent pkg in winrepo

### DIFF
--- a/winrepo/winrepo/mcafee_agent_pkg/init.sls
+++ b/winrepo/winrepo/mcafee_agent_pkg/init.sls
@@ -1,0 +1,60 @@
+{#- Set the name of the winrepo package. -#}
+{%- set name = 'mcafee-agent' -%}
+
+{#-
+Define variables that may be unique to the system and are required for one of
+the winrepo parameters.
+-#}
+
+{#- Define a list of versions. -#}
+{%- set versions = [ '5.00.1009' ] -%}
+
+{#-
+Initialize the `package` dictionary, which will contain the information needed
+for the winrepo package definition. This dictionary is structured so that the
+jinja content can be separated into another file, and this single variable can
+be imported into an accompanying winrepo sls file.
+-#}
+{%- load_yaml as package -%}
+name: {{ name }}
+pillar: '{{ name }}:winrepo'
+{# `common_params` are winrepo params that are the same for all versions. #}
+common_params:
+  full_name: 'McAfee Agent'
+  install_flags: ' /install=agent /forceinstall /silent'
+  msiexec: False
+  uninstaller: '%ProgramFiles%\McAfee\Agent\x86\FrmInst.exe'
+  uninstall_flags: ' /forceuninstall /silent'
+{# `versions` are winrepo params that are distinct per version. #}
+versions:
+  {% for version in versions %}
+  '{{ version }}':
+    installer: >-
+      https://path/to/your/FramePkg.exe
+  {% endfor %}
+{%- endload -%}
+
+{#-
+Update and merge the `package.versions` dictionary with winrepo version
+settings from pillar.
+-#}
+{%-
+do package.versions.update(salt['pillar.get'](
+    package.pillar ~ ':versions',
+    default=package.versions,
+    merge=True))
+-%}
+
+{#-
+Create the winrepo state definition, looping over the versions and merging in
+the `package.common_params` dictionary.
+-#}
+{{ package.name }}:
+  {%- for version,params in package.versions.items() %}
+  {%- do params.update(salt['pillar.get'](
+      package.pillar ~ ':common_params',
+      default=package.common_params,
+      merge=True)) %}
+  '{{ version }}':
+    {{ params | yaml }}
+  {%- endfor %}

--- a/winrepo/winrepo/trellix_agent_pkg/init.sls
+++ b/winrepo/winrepo/trellix_agent_pkg/init.sls
@@ -1,5 +1,5 @@
 {#- Set the name of the winrepo package. -#}
-{%- set name = 'mcafee-agent' -%}
+{%- set name = 'trellix-agent' -%}
 
 {#-
 Define variables that may be unique to the system and are required for one of
@@ -20,10 +20,10 @@ name: {{ name }}
 pillar: '{{ name }}:winrepo'
 {# `common_params` are winrepo params that are the same for all versions. #}
 common_params:
-  full_name: 'McAfee Agent'
+  full_name: 'Trellix Agent'
   install_flags: ' /install=agent /forceinstall /silent'
   msiexec: False
-  uninstaller: '%ProgramFiles%\McAfee\Agent\x86\FrmInst.exe'
+  uninstaller: '%ProgramFiles%\Trellix\Agent\x86\FrmInst.exe'
   uninstall_flags: ' /forceuninstall /silent'
 {# `versions` are winrepo params that are distinct per version. #}
 versions:


### PR DESCRIPTION
Made changes related to this task:
1. Copy winrepo/winrepo/mcafee-agent to trellix-agent
2. Rename “mcafee” with “trellix”, being careful to match case
3. Search repo for other mentions of “mcafee”.