### PR TITLE
Corrects content-mapping for Alma Linux 9

### DIFF
--- a/pillar/common/ash-linux/init.sls
+++ b/pillar/common/ash-linux/init.sls
@@ -8,7 +8,7 @@
         'Rocky': 'centos8',
     }, grain='os'),
     9: salt.grains.filter_by({
-        'AlmaLinux': 'cs9',
+        'AlmaLinux': 'almalinux9',
         'CentOS Stream': 'cs9',
         'OEL': 'ol9',
         'RedHat': 'rhel9',


### PR DESCRIPTION
Closes #61 by changing `AlmaLinux` mapping-value from `cs9` to `almalinux9`